### PR TITLE
Make message merging work

### DIFF
--- a/tsmarty2c.php
+++ b/tsmarty2c.php
@@ -194,7 +194,7 @@ if (isset($opt['o'])) {
 }
 
 // initialize output
-file_put_contents($outfile, MSGID_HEADER);
+// NEEDS FIX: file_put_contents($outfile, MSGID_HEADER);
 
 // process dirs/files
 foreach ($argv as $arg) {


### PR DESCRIPTION
Line 197 breaks message merging (updating existing po file when "-o" option is used), because output file is overwritten before any merging takes place and previous translations are lost.