### PR TITLE
fix for template_dir is array without key of zero defined 

### DIFF
--- a/function.locale.php
+++ b/function.locale.php
@@ -35,9 +35,17 @@ function smarty_function_locale($params, &$smarty) {
 	}
 
 	$template_dir = method_exists($smarty, 'getTemplateDir') ? $smarty->getTemplateDir() : $smarty->template_dir;
-	$template_dir = is_array($template_dir) ? $template_dir[0] : $template_dir;
+	if(!is_array($template_dir)){
+		$template_dir = array($template_dir);
+	}
 
-	$path = $template_dir . $params['path'];
+	foreach($template_dir as $template_dir_item){
+		$path = $template_dir_item . $params['path'];
+		if(is_dir($path)){
+			break;
+		}
+	}
+
 	$domain = isset($params['domain']) ? $params['domain'] : 'messages';
 	$stack_operation = isset($params['stack']) ? $params['stack'] : 'push';
 

--- a/function.locale.php
+++ b/function.locale.php
@@ -34,6 +34,8 @@ function smarty_function_locale($params, &$smarty) {
 		$stack = array();
 	}
 
+	$params['path'] = isset($params['path']) ? $params['path'] : '';
+
 	$template_dir = method_exists($smarty, 'getTemplateDir') ? $smarty->getTemplateDir() : $smarty->template_dir;
 	if(!is_array($template_dir)){
 		$template_dir = array($template_dir);

--- a/tests/LocaleTest.php
+++ b/tests/LocaleTest.php
@@ -60,7 +60,7 @@ class TestLocale extends TestCase {
 		$res = $this->t("Welcome! ", array());
 		$this->assertEquals("Witaj! - messages2", $res);
 
-		$this->locale(array('path' => self::$i18ndir, 'stack' => 'pop'));
+		$this->locale(array('stack' => 'pop'));
 		$res = $this->t("Welcome! ", array());
 		$this->assertEquals("Witaj! ", $res);
 	}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -56,9 +56,9 @@ class TestCase extends PHPUnit_Framework_TestCase {
 		$smarty = new Smarty();
 
 		if (method_exists($smarty, 'getTemplateDir')) {
-			$smarty->setTemplateDir($template_dir);
+			$smarty->setTemplateDir($template_dir,'test');
 		} else {
-			$smarty->template_dir = $template_dir;
+			$smarty->template_dir['test'] = $template_dir;
 		}
 
 		return $smarty;

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -58,7 +58,7 @@ class TestCase extends PHPUnit_Framework_TestCase {
 		if (method_exists($smarty, 'getTemplateDir')) {
 			$smarty->setTemplateDir($template_dir,'test');
 		} else {
-			$smarty->template_dir['test'] = $template_dir;
+			$smarty->template_dir = $template_dir;
 		}
 
 		return $smarty;

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -54,9 +54,9 @@ class TestCase extends PHPUnit_Framework_TestCase {
 	 */
 	private static function getSmarty($template_dir = '/') {
 		$smarty = new Smarty();
-
 		if (method_exists($smarty, 'getTemplateDir')) {
-			$smarty->setTemplateDir($template_dir,'test');
+			$smarty->addTemplateDir($template_dir.'-WRONG','test-false');
+			$smarty->addTemplateDir($template_dir,'test-good');
 		} else {
 			$smarty->template_dir = $template_dir;
 		}


### PR DESCRIPTION
Hi There,

I have written a fix for if the array contains diffrent keys then 0,1,2,3,4....
Before the locale function only pickes $template_dir[0]. Now the function will pick the first directory in order of the array if the template_dir is a directory including the params['path'].

Also have a fallback if the path is not defined, for example with stack="pop" (then the path is not necessary)

Please add it upstream so we can use the packagist packages.

Thanks,

Tim