### PR TITLE
Added support for extracting strings of a specific domain only

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,4 +1,4 @@
-## [1.4.1] - 2016-10-30
+## [1.5.0] - 2016-11-03
 
 IMPROVEMENTS:
   - fix for `template_dir` is array without key of zero defined. [#14]
@@ -122,7 +122,7 @@ BUG FIXES:
  [#14]: https://github.com/smarty-gettext/smarty-gettext/pull/14
 [azatoth/php-pgettext]: https://packagist.org/packages/azatoth/php-pgettext
 
-[1.4.1]: https://github.com/smarty-gettext/smarty-gettext/compare/1.4.1...1.4.1
+[1.5.0]: https://github.com/smarty-gettext/smarty-gettext/compare/1.4.1...1.5.0
 [1.4.0]: https://github.com/smarty-gettext/smarty-gettext/compare/1.3.0...1.4.0
 [1.3.0]: https://github.com/smarty-gettext/smarty-gettext/compare/1.2.0...1.3.0
 [1.2.0]: https://github.com/smarty-gettext/smarty-gettext/compare/1.1.1...1.2.0

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,8 @@
+## [1.4.1] - 2016-10-30
+
+IMPROVEMENTS:
+  - fix for `template_dir` is array without key of zero defined. [#14]
+
 ## [1.4.0] - 2016-06-13
 
 IMPROVEMENTS:
@@ -114,8 +119,10 @@ BUG FIXES:
  [#7]: https://github.com/smarty-gettext/smarty-gettext/pull/7
  [#8]: https://github.com/smarty-gettext/smarty-gettext/issues/8
  [#10]: https://github.com/smarty-gettext/smarty-gettext/pull/10
+ [#14]: https://github.com/smarty-gettext/smarty-gettext/pull/14
 [azatoth/php-pgettext]: https://packagist.org/packages/azatoth/php-pgettext
 
+[1.4.1]: https://github.com/smarty-gettext/smarty-gettext/compare/1.4.1...1.4.1
 [1.4.0]: https://github.com/smarty-gettext/smarty-gettext/compare/1.3.0...1.4.0
 [1.3.0]: https://github.com/smarty-gettext/smarty-gettext/compare/1.2.0...1.3.0
 [1.2.0]: https://github.com/smarty-gettext/smarty-gettext/compare/1.1.1...1.2.0

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -93,7 +93,7 @@ BUG FIXES:
 	- rename to smarty-gettext
 	- correct package name, project urls, add version
 
-## 0.9 - 2004-03-01 Sagi Bashari
+## [0.9] - 2004-03-01 Sagi Bashari
 
 * tsmarty2c.php:
 	- added support for directories (originally by [Uros Gruber][4])
@@ -124,3 +124,4 @@ BUG FIXES:
 [1.0.1]: https://github.com/smarty-gettext/smarty-gettext/compare/1.0b1...1.0.1
 [1.0b1]: https://github.com/smarty-gettext/smarty-gettext/compare/0.9.1...1.0b1
 [0.9.1]: https://github.com/smarty-gettext/smarty-gettext/compare/0.9...0.9.1
+[0.9]: https://github.com/smarty-gettext/smarty-gettext/commits/0.9

--- a/function.locale.php
+++ b/function.locale.php
@@ -48,7 +48,7 @@ function smarty_function_locale($params, &$smarty) {
 	}
 
 	if (!$path && $stack_operation != 'pop') {
-		trigger_error("Missing 'path' parameter.", E_USER_ERROR);
+		trigger_error("Directory for locales not found (path='{$path_param}')", E_USER_ERROR);
 	}
 
 	if ($stack_operation == 'push') {


### PR DESCRIPTION
- Use `-d` to extract gettext strings of default (empty) domain only
- Use `-d=custom` to extract gettext strings of "custom" domain only (e.g. all strings defined with `{t domain="custom"}...`)