### PR TITLE
Fix license identifier

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
 	"name": "smarty-gettext/smarty-gettext",
 	"description": "Gettext plugin enabling internationalization in Smarty Package files",
 	"homepage": "https://github.com/smarty-gettext/smarty-gettext",
-	"license": "LGPL-2.1+",
+	"license": "LGPL-2.1",
 	"authors": [
 		{
 			"name": "Sagi Bashari",


### PR DESCRIPTION
As per https://spdx.org/licenses/LGPL-2.1+ the license identifier `LGPL-2.1+` has been deprecated. This PR updates the identifier to `LGPL-2.1` which helps automated license checking tools verify your package.