### PR TITLE
Use single and double quotes in parameter values

### DIFF
--- a/tsmarty2c.php
+++ b/tsmarty2c.php
@@ -115,8 +115,8 @@ function do_file($outfile, $file) {
 		$plural = null;
 
 		if (defined('DOMAIN')) {
-			if (preg_match('/domain\s*=\s*["\']?\s*(.[^\"\']*)\s*["\']?/', $matches[2][$i][0], $match)) {
-				if($match[1] != DOMAIN) {
+			if (preg_match('/domain\s*=\s*(["'])((?:[^\\\1]|\\.)*)\1/', $matches[2][$i][0], $match)) {
+				if($match[2] != DOMAIN) {
 					continue; // Skip strings with domain, if not matching domain to extract
 				}
 			} elseif (DOMAIN != '') {
@@ -124,13 +124,13 @@ function do_file($outfile, $file) {
 			}
 		}
 
-		if (preg_match('/context\s*=\s*["\']?\s*(.[^\"\']*)\s*["\']?/', $matches[2][$i][0], $match)) {
-			$msg_ctxt = $match[1];
+		if (preg_match('/context\s*=\s*(["'])((?:[^\\\1]|\\.)*)\1/', $matches[2][$i][0], $match)) {
+			$msg_ctxt = $match[2];
 		}
 
-		if (preg_match('/plural\s*=\s*["\']?\s*(.[^\"\']*)\s*["\']?/', $matches[2][$i][0], $match)) {
+		if (preg_match('/plural\s*=\s*(["'])((?:[^\\\1]|\\.)*)\1/', $matches[2][$i][0], $match)) {
 			$msgid = $matches[3][$i][0];
-			$plural = $match[1];
+			$plural = $match[2];
 		} else {
 			$msgid = $matches[3][$i][0];
 		}

--- a/tsmarty2c.php
+++ b/tsmarty2c.php
@@ -229,8 +229,11 @@ if ('cli' != php_sapi_name()) {
 
 define('PROGRAM', basename(array_shift($argv)));
 define('TMPDIR', sys_get_temp_dir());
-$opt = getopt('o:d::');
+$opt = getopt('o:d::', array('tag-open:', 'tag-close:'));
+
 $outfile = isset($opt['o']) ? $opt['o'] : tempnam(TMPDIR, 'tsmarty2c');
+$ldq = isset($opt['tag-open' ]) ? preg_quote($opt['tag-open' ]) : $ldq;
+$rdq = isset($opt['tag-close']) ? preg_quote($opt['tag-close']) : $rdq;
 
 // remove -o FILENAME from $argv.
 if (isset($opt['o'])) {
@@ -238,7 +241,6 @@ if (isset($opt['o'])) {
 		if ($v != '-o') {
 			continue;
 		}
-
 		unset($argv[$i]);
 		unset($argv[$i + 1]);
 		break;
@@ -254,6 +256,16 @@ if (isset($opt['d'])) {
 		}
 		unset($argv[$i]);
 		break;
+	}
+}
+
+// remove --tag-open="TAG" and --tag-close="TAG" from $argv.
+if (isset($opt['tag-open']) or isset($opt['tag-close'])) {
+	foreach ($argv as $i => $v) {
+		if (!preg_match('/^--tag-(?:open|close)/',$v)) {
+			continue;
+		}
+		unset($argv[$i]);
 	}
 }
 


### PR DESCRIPTION
Dear maintainer,

with this pull request your plugin gets the possibility to use single and double quotes in
parameter values of the t-block.
Here an example: {t plural='single ' and double " quote'}
The reason, why i did this change is that i want to use HTML code in the plural parameter e.g. a link with href and double quotes.
Only the regex string and the index of the matching array is changed.
I am afraid, but there are no tests of this change because i do not getting my test environment to work in a small amount of time.

Kind regards
Lukas Rühl