### PR TITLE
Update Readme for Smarty 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-**Gettext support for Smarty2/Smarty3**
+**Gettext support for Smarty2/Smarty3/Smarty4**
 =======================================
 
 [![License](https://poser.pugx.org/smarty-gettext/smarty-gettext/license.png)](https://packagist.org/packages/smarty-gettext/smarty-gettext)


### PR DESCRIPTION
smarty-gettext is compatible with Smarty version >= 4 without any changes
 
 Fixes https://github.com/smarty-gettext/smarty-gettext/issues/42